### PR TITLE
Use name helpers for matching aliases

### DIFF
--- a/R/names_helpers.R
+++ b/R/names_helpers.R
@@ -2,13 +2,14 @@ standardise_names <- function(names) {
   sd_names <- tolower(names) %>%
     trimws() %>%
     str_replace_all(" ", "_") %>%
-    str_replace_all("&", "and")
+    str_replace_all("&", "_and_")
   sd_names
 }
 
 make_pretty_labels <- function(names) {
-  pretty_names <- r2dii.plot::to_title(names) %>%
-    str_replace_all("And", "and") %>%
-    r2dii.plot::spell_out_technology()
+  pretty_names <- standardise_names(names) %>%
+    r2dii.plot::to_title() %>%
+    r2dii.plot::spell_out_technology() %>%
+    str_replace_all("And", "and")
   pretty_names
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,15 +24,15 @@ deparse_1 <- function(expr, collapse = " ", width.cutoff = 500L, ...) {
 add_colours_missing_names <- function(names, colour_aliases) {
   # add colours to names differing by letter case
   names <- unique(names)
-  names_lower <- unique(tolower(names))
-  missing_names_core <- setdiff(names_lower, names(colour_aliases))
+  names_standard <- unique(standardise_names(names))
+  missing_names_core <- setdiff(names_standard, names(colour_aliases))
   missing_names_lettercase <- setdiff(names, names(colour_aliases))
   if (length(missing_names_core) < length(missing_names_lettercase)) {
     names_case_difference <-
       setdiff(missing_names_lettercase, missing_names_core)
     aliases_case_difference <- c()
     for (i in seq_along(names_case_difference)) {
-      colour <- colour_aliases[tolower(names_case_difference[i])]
+      colour <- colour_aliases[standardise_names(names_case_difference[i])]
       aliases_case_difference <- c(
         aliases_case_difference,
         setNames(colour, names_case_difference[i])
@@ -43,7 +43,7 @@ add_colours_missing_names <- function(names, colour_aliases) {
   # add colours to names that are not in aliases
   if (length(missing_names_core) > 0) {
     all_colours <- colour_aliases[names(colour_aliases) == ""]
-    available_colours <- setdiff(all_colours, colour_aliases[c(names, names_lower)])
+    available_colours <- setdiff(all_colours, colour_aliases[c(names, names_standard)])
     if (length(missing_names_core) <= length(available_colours)) {
       missing_aliases <- setNames(
         available_colours[seq_along(missing_names_core)],

--- a/tests/testthat/test-scale_colour_2dii.R
+++ b/tests/testthat/test-scale_colour_2dii.R
@@ -89,12 +89,12 @@ test_that("with bad palette errors gracefully", {
 test_that("warns about assigning colours", {
   expect_message(
     example_plot_scale_colour() +
-      scale_colour_2dii(colour_groups = r2dii.plot::sda$sector),
+      scale_colour_2dii("1in1000", colour_groups = r2dii.plot::sda$sector),
     regexp = "Assigning colours to unrecognised names in data"
   )
   expect_message(
     example_plot_scale_fill() +
-      scale_fill_2dii(colour_groups = r2dii.plot::sda$sector),
+      scale_fill_2dii("1in1000", colour_groups = r2dii.plot::sda$sector),
     regexp = "Assigning colours to unrecognised names in data"
   )
 })


### PR DESCRIPTION
In this PR I improve the way that names in date are matched with colour aliases. In particular, "oil&gas" is now correctly matched to alias "oil_and_gas"